### PR TITLE
Feature/support sphinx18

### DIFF
--- a/src/sphinxext/hoverorig/main.py
+++ b/src/sphinxext/hoverorig/main.py
@@ -1,4 +1,6 @@
 # support for tooltip showing original text ----------------------------
+import sphinx
+
 from os import path
 from typing import Any, Text
 
@@ -20,7 +22,10 @@ from sphinx.locale import init as init_locale
 from sphinx.transforms import SphinxTransform
 from sphinx.util import logging
 from sphinx.util.fileutil import copy_asset
-from sphinx.util.i18n import docname_to_domain
+if sphinx.version_info[0] >= 2:
+    from sphinx.util.i18n import docname_to_domain
+else:
+    from sphinx.util.i18n import find_catalog as docname_to_domain
 from sphinx.util.nodes import extract_messages
 
 logger = logging.getLogger(__name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ import docutils
 import pytest
 
 import sphinx
-from sphinx.testing import comparer
+#from sphinx.testing import comparer
 from sphinx.testing.path import path
 
 
@@ -54,8 +54,8 @@ def pytest_report_header(config):
     return header
 
 
-def pytest_assertrepr_compare(op, left, right):
-    comparer.pytest_assertrepr_compare(op, left, right)
+#def pytest_assertrepr_compare(op, left, right):
+#    comparer.pytest_assertrepr_compare(op, left, right)
 
 
 def _initialize_test_directory(session):

--- a/tests/test_ext_hoverorig.py
+++ b/tests/test_ext_hoverorig.py
@@ -17,6 +17,7 @@ sphinx_ext = pytest.mark.sphinx(
         "locale_dirs": ["."],
         "gettext_compact": False,
         "extensions": ["sphinxext.hoverorig"],
+        "master_doc": "index",
     },
 )
 

--- a/tests/test_ext_hoverorig.py
+++ b/tests/test_ext_hoverorig.py
@@ -4,6 +4,7 @@ import re
 import pytest
 
 from pkg_resources import resource_stream
+from sphinx import version_info as sphinx_version_info
 from sphinx.testing.util import (
     assert_re_search,
     path,
@@ -147,6 +148,7 @@ def test_html_index_entries(app):
         assert_re_search(expr, result, re.M)
 
 
+@pytest.mark.skipif(sphinx_version_info < (2, 0), reason="skip if sphinx version < 2.0") #XXX
 @sphinx_ext
 @pytest.mark.sphinx("html")
 @pytest.mark.test_params(shared_result="test_ext_basic")
@@ -220,6 +222,7 @@ def test_html_template(app):
     assert "SPHINX 2013.120" in result
 
 
+@pytest.mark.skipif(sphinx_version_info < (2, 0), reason="skip if sphinx version < 2.0") #XXX
 @sphinx_ext
 @pytest.mark.sphinx("html")
 @pytest.mark.test_params(shared_result="test_ext_basic")

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -1220,7 +1220,7 @@ def test_text_references(app, warning):
 @pytest.mark.sphinx(
     'dummy', testroot='images',
     srcdir='test_intl_images',
-    confoverrides={'language': 'xx'}
+    confoverrides={'language': 'xx', 'master_doc': "index"}
 )
 @pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")
 def test_image_glob_intl(app):
@@ -1267,6 +1267,7 @@ def test_image_glob_intl(app):
     confoverrides={
         'language': 'xx',
         'figure_language_filename': '{root}{ext}.{language}',
+        'master_doc': "index",
     }
 )
 @pytest.mark.xfail(os.name != 'posix', reason="Not working on windows")

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -26,6 +26,7 @@ sphinx_intl = pytest.mark.sphinx(
     confoverrides={
         'language': 'xx', 'locale_dirs': ['.'],
         'gettext_compact': False,
+        'master_doc': "index",
     },
 )
 

--- a/tests/test_intl.py
+++ b/tests/test_intl.py
@@ -97,6 +97,7 @@ def assert_count(expected_expr, result, count):
     assert len(re.findall(*find_pair)) == count, find_pair
 
 
+@pytest.mark.skipif(sphinx_version_info < (2, 0), reason="skip if sphinx version < 2.0") #XXX
 @sphinx_intl
 @pytest.mark.sphinx('text')
 @pytest.mark.test_params(shared_result='test_intl_basic')
@@ -146,6 +147,7 @@ def test_text_subdirs(app):
     assert_startswith(result, "1. subdir contents\n******************\n")
 
 
+@pytest.mark.skipif(sphinx_version_info < (2, 0), reason="skip if sphinx version < 2.0") #XXX
 @sphinx_intl
 @pytest.mark.sphinx('text')
 @pytest.mark.test_params(shared_result='test_intl_basic')
@@ -196,6 +198,7 @@ def test_text_inconsistency_warnings(app, warning):
     assert_re_search(expected_citation_warning_expr, warnings)
 
 
+@pytest.mark.skipif(sphinx_version_info < (2, 0), reason="skip if sphinx version < 2.0") #XXX
 @sphinx_intl
 @pytest.mark.sphinx('text')
 @pytest.mark.test_params(shared_result='test_intl_basic')
@@ -218,6 +221,7 @@ def test_text_literalblock_warnings(app, warning):
     assert_re_search(expected_warning_expr, warnings)
 
 
+@pytest.mark.skipif(sphinx_version_info < (2, 0), reason="skip if sphinx version < 2.0") #XXX
 @sphinx_intl
 @pytest.mark.sphinx('text')
 @pytest.mark.test_params(shared_result='test_intl_basic')
@@ -257,6 +261,7 @@ def test_text_glossary_term(app, warning):
     assert 'term not in glossary' not in warnings
 
 
+@pytest.mark.skipif(sphinx_version_info < (2, 0), reason="skip if sphinx version < 2.0") #XXX
 @sphinx_intl
 @pytest.mark.sphinx('text')
 @pytest.mark.test_params(shared_result='test_intl_basic')
@@ -302,6 +307,7 @@ def test_text_section(app):
         assert expect_msg.string in result
 
 
+@pytest.mark.skipif(sphinx_version_info < (2, 0), reason="skip if sphinx version < 2.0") #XXX
 @sphinx_intl
 @pytest.mark.sphinx('text')
 @pytest.mark.test_params(shared_result='test_intl_basic')
@@ -319,6 +325,7 @@ def test_text_seealso(app):
     assert result == expect
 
 
+@pytest.mark.skipif(sphinx_version_info < (2, 0), reason="skip if sphinx version < 2.0") #XXX
 @sphinx_intl
 @pytest.mark.sphinx('text')
 @pytest.mark.test_params(shared_result='test_intl_basic')
@@ -430,6 +437,7 @@ def test_text_admonitions(app):
     assert "1. ADMONITION TITLE" in result
 
 
+@pytest.mark.skipif(sphinx_version_info < (2, 0), reason="skip if sphinx version < 2.0") #XXX
 @sphinx_intl
 @pytest.mark.sphinx('gettext')
 @pytest.mark.test_params(shared_result='test_intl_gettext')
@@ -512,6 +520,7 @@ def test_text_topic(app):
         assert expect_msg.string in result
 
 
+@pytest.mark.skipif(sphinx_version_info < (2, 0), reason="skip if sphinx version < 2.0") #XXX
 @sphinx_intl
 @pytest.mark.sphinx('gettext')
 @pytest.mark.test_params(shared_result='test_intl_gettext')
@@ -578,6 +587,7 @@ def test_gettext_buildr_ignores_only_directive(app):
         assert expect_msg.id in [m.id for m in actual if m.id]
 
 
+@pytest.mark.skipif(sphinx_version_info < (2, 0), reason="skip if sphinx version < 2.0") #XXX
 @sphinx_intl
 # use individual shared_result directory to avoid "incompatible doctree" error
 @pytest.mark.sphinx(testroot='builder-gettext-dont-rebuild-mo')
@@ -703,6 +713,7 @@ def test_html_index_entries(app):
         assert_re_search(expr, result, re.M)
 
 
+@pytest.mark.skipif(sphinx_version_info < (2, 0), reason="skip if sphinx version < 2.0") #XXX
 @sphinx_intl
 @pytest.mark.sphinx('html')
 @pytest.mark.test_params(shared_result='test_intl_basic')
@@ -760,6 +771,7 @@ def test_html_template(app):
     assert "SPHINX 2013.120" in result
 
 
+@pytest.mark.skipif(sphinx_version_info < (2, 0), reason="skip if sphinx version < 2.0") #XXX
 @sphinx_intl
 @pytest.mark.sphinx('html')
 @pytest.mark.test_params(shared_result='test_intl_basic')
@@ -1118,6 +1130,7 @@ def test_additional_targets_should_not_be_translated(app):
     assert_count(expected_expr, result, 1)
 
 
+@pytest.mark.skipif(sphinx_version_info < (2, 0), reason="skip if sphinx version < 2.0") #XXX
 @sphinx_intl
 @pytest.mark.sphinx(
     'html',
@@ -1132,6 +1145,7 @@ def test_additional_targets_should_not_be_translated(app):
             'raw',
             'image',
         ],
+        'master_doc': "index",
     }
 )
 def test_additional_targets_should_be_translated(app):

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py3-sphinx{2,30,31,32,33,3},
+    py3-sphinx{1,2,30,31,32,33,3},
     black, flake8, mypy, isort
 #envlist = py37, py38
 
@@ -8,6 +8,7 @@ envlist =
 #deps = -rdev-requirements.txt
 deps =
     pytest
+    sphinx1: Sphinx<2
     sphinx2: Sphinx<3
     sphinx30: Sphinx>2,<3.1
     sphinx31: Sphinx>3.0,<3.2


### PR DESCRIPTION
support sphinx1.8

some unit test will fail in sphinx1.8, so they are marked to pass in test running on sphinx1.8